### PR TITLE
Fixes android launch/splash screen styles and it not showing

### DIFF
--- a/packages/WillowCreekApp/android/app/src/main/AndroidManifest.xml
+++ b/packages/WillowCreekApp/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,9 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustPan"
-        android:launchMode="singleTask">
+        android:launchMode="singleTask"
+        android:theme="@style/LaunchTheme"
+        >
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/packages/WillowCreekApp/android/app/src/main/java/com/willowcreekapp/MainActivity.java
+++ b/packages/WillowCreekApp/android/app/src/main/java/com/willowcreekapp/MainActivity.java
@@ -9,7 +9,7 @@ import org.devio.rn.splashscreen.SplashScreen;
 public class MainActivity extends ReactActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        SplashScreen.show(this);
+        SplashScreen.show(this, R.style.LaunchTheme);
         super.onCreate(savedInstanceState);
     }
     /**

--- a/packages/WillowCreekApp/android/app/src/main/res/drawable/background_splash.xml
+++ b/packages/WillowCreekApp/android/app/src/main/res/drawable/background_splash.xml
@@ -13,15 +13,15 @@
                 android:angle="135"
                 android:startColor="#092d74"
                 android:centerColor="#0070b9"
-                android:centerX="70%"
+                android:centerX="65%"
                 android:centerY="90%"
                 android:endColor="#7500ffea"
                 />
         </shape>
     </item>
     <item
-        android:width="95.28dp"
-        android:height="100dp"
+        android:width="150dp"
+        android:height="150dp"
         android:top="-24dp"
         android:drawable="@mipmap/splash_icon"
         android:gravity="center" />

--- a/packages/WillowCreekApp/android/app/src/main/res/values-v21/styles.xml
+++ b/packages/WillowCreekApp/android/app/src/main/res/values-v21/styles.xml
@@ -6,6 +6,6 @@
 
     <style name="LaunchTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowBackground">@drawable/background_splash</item>
-        <item name="colorPrimaryDark">@color/splashBg</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 </resources>


### PR DESCRIPTION
## DESCRIPTION
<img src="https://user-images.githubusercontent.com/2053547/69467230-07a73000-0d55-11ea-8a18-012adfea4ee2.png" width="50%" />

### What design trade-offs/decisions were made?
There is still an issue when the app mounts I think we are dismissing the launch screen too early so we see a loading spinner when we should but I'll address that in a different PR. 

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
