### PR TITLE
Refetch discover feed when changing campuses

### DIFF
--- a/packages/WillowCreekApp/src/user-settings/Locations/index.js
+++ b/packages/WillowCreekApp/src/user-settings/Locations/index.js
@@ -10,6 +10,7 @@ import { get } from 'lodash';
 import GET_USER_FEED from '../../tabs/home/getUserFeed';
 import GET_FEED_FEATURES from '../../tabs/home/Features/getFeedFeatures';
 import GET_CAMPAIGN_CONTENT_ITEM from '../../tabs/home/getCampaignContentItem';
+import GET_CONTENT_CHANNELS from '../../tabs/discover/DiscoverFeed/getContentChannels';
 
 import GET_CAMPUSES from './getCampusLocations';
 import CHANGE_CAMPUS from './campusChange';
@@ -97,6 +98,7 @@ class Location extends PureComponent {
               },
               { query: GET_CAMPAIGN_CONTENT_ITEM, variables: undefined },
               { query: GET_FEED_FEATURES, variables: undefined },
+              { query: GET_CONTENT_CHANNELS, variables: undefined },
             ]}
           >
             {(handlePress) => (


### PR DESCRIPTION
## DESCRIPTION

- Switching campuses should refetch the discover screen.

### What does this PR do, or why is it needed?

Adds `GET_CONTENT_CHANNELS` query to the list of refetchQueries in user locations component. Similar to the work that was done for the Home feed https://github.com/Differential/willow-prototype/pull/40

### How do I test this PR?

Change your selected campus and click over to the discover screen relevant content should be loaded for your campus.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] Closes [tag-issues-here]
          Issue on Basecamp
- [x] No new warnings in tests, in storybook, and in-app
- [x] Upload GIF(s) of iOS and Android
          iOS - https://v.usetapes.com/7bDWgzSv7d
          Android - https://v.usetapes.com/XI5XEoosOn
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
