### PR TITLE
Disable amplitude identify when local

### DIFF
--- a/packages/WillowCreekApp/src/amplitude.js
+++ b/packages/WillowCreekApp/src/amplitude.js
@@ -33,6 +33,7 @@ export const identify = () => {
     `,
   });
 
+  // The functions called next throw an error in development, so we bypass them early.
   if (
     process.env.NODE_ENV === 'development' ||
     process.env.NODE_ENV === 'testing'

--- a/packages/WillowCreekApp/src/amplitude.js
+++ b/packages/WillowCreekApp/src/amplitude.js
@@ -33,6 +33,12 @@ export const identify = () => {
     `,
   });
 
+  if (
+    process.env.NODE_ENV === 'development' ||
+    process.env.NODE_ENV === 'testing'
+  )
+    return;
+
   amplitude.getInstance().setUserId(get(data, 'currentUser.profile.id'));
 
   amplitude.getInstance().setUserProperties({


### PR DESCRIPTION
## DESCRIPTION

 Context: https://differential.slack.com/archives/CH07DTXT9/p1574697009001600

Currently an error is thrown in the Willow app locally. You can simply dismiss it, but it seems to be related to the Amplitude Analytics.
![image](https://user-images.githubusercontent.com/2528817/69584583-21d64d80-0fa3-11ea-9a2e-33eeca0cce05.png)

It might be that I just need Amplitude env variable locally to solve this problem but, didn't have one. 🤷‍♂️So, this PR is checking NODE_ENV and just returning if you are in development or testing environment.

### What does this PR do, or why is it needed?

Checks to see if you are local and just returns instead of running amplitude. Possible extra benefit is it avoids the need for a valid amplitude api key.

### How do I test this PR?

Load up Willow app and don't see error.

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
