### PR TITLE
Removes images from events

### DIFF
--- a/packages/apollos-api/src/data/event/index.js
+++ b/packages/apollos-api/src/data/event/index.js
@@ -26,6 +26,8 @@ const resolver = resolverMerge(
       },
       url: (root) =>
         `https://rock.willowcreek.org/page/439?EventOccurrenceId=${root.id}`,
+      // Current app design calls for no user-supplied images.
+      image: () => null,
     },
   },
   Event

--- a/packages/apollos-api/src/data/features/data-source.js
+++ b/packages/apollos-api/src/data/features/data-source.js
@@ -106,7 +106,9 @@ export default class Features extends baseFeatures.dataSource {
         .tz('America/Chicago')
         .format('dddd, MMM D'),
       relatedNode: { ...event, __type: 'Event' },
-      image: Event.getImage(event),
+      // image: Event.getImage(event),
+      // Current app design calls for no user-supplied images.
+      image: null,
       action: 'OPEN_URL',
     }));
   }


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Removes the images from lists of events. As of right now, we don't want to display them in the app. We might have issues down the road if we ever want to display event images when tapping into events, but we can safely back out the resolver change in the future without breaking existing apps.

### What design trade-offs/decisions were made?

### How do I test this PR?

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
