### PR TITLE
Existing user's shouldn't be able to edit their profile

### DIFF
--- a/packages/WillowCreekApp/src/ui/Onboarding/AskNameConnected.js
+++ b/packages/WillowCreekApp/src/ui/Onboarding/AskNameConnected.js
@@ -90,7 +90,7 @@ const AskNameConnected = memo(
                     touched={touched}
                     errors={errors}
                     setFieldValue={setFieldValue}
-                    existingUser={authStatus === 'NEW_USER_WITH_ROCK_PROFILE'}
+                    existingUser={authStatus !== 'NEW_USER'}
                     isLoading={loading || isSubmitting}
                     {...props}
                   />


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This PR makes sure that users who have already signed up, don't get the chance to change their profile info. 

This stops a bug where a user would sign up and be matched with a phone number under the wrong name, and then that user would be able to logout and log back in again and change their name the second time around.

Now, existing user's will always be shown the "not you? logout and create an email/password account" screen.

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

1. Logout of the app.
3. Log back into the app
4. You should not be able to edit your first/last name in onboarding

### What automated tests did you write?

n/a

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
