### PR TITLE
Order devotionals correctly

### DIFF
--- a/packages/apollos-api/src/data/content-items/data-source.js
+++ b/packages/apollos-api/src/data/content-items/data-source.js
@@ -15,19 +15,20 @@ class ExtendedContentItem extends ContentItem.dataSource {
     return '';
   };
 
+  _getCursorByParentContentItemId = this.getCursorByParentContentItemId;
+
   getCursorByParentContentItemId = async (id) => {
-    const associations = await this.request('ContentChannelItemAssociations')
-      .filter(`ContentChannelItemId eq ${id}`)
-      .cache({ ttl: 60 })
-      .get();
+    const cursor = await this._getCursorByParentContentItemId(id);
 
-    if (!associations || !associations.length) return this.request().empty();
+    return cursor.orderBy('Priority'); // Changed from Core, ordering by Priority instead of 'order'
+  };
 
-    return this.getFromIds(
-      associations.map(
-        ({ childContentChannelItemId }) => childContentChannelItemId
-      )
-    ).orderBy('Priority'); // Changed from Core, ordering by Priority instead of 'order'
+  _getCursorBySiblingContentItemId = this.getCursorBySiblingContentItemId;
+
+  getCursorBySiblingContentItemId = async (id) => {
+    const cursor = await this._getCursorBySiblingContentItemId(id);
+
+    return cursor.orderBy('Priority'); // Changed from Core, ordering by Priority instead of 'order'
   };
 
   async getCoverImage(root) {

--- a/packages/apollos-api/src/data/content-items/data-source.js
+++ b/packages/apollos-api/src/data/content-items/data-source.js
@@ -15,6 +15,21 @@ class ExtendedContentItem extends ContentItem.dataSource {
     return '';
   };
 
+  getCursorByParentContentItemId = async (id) => {
+    const associations = await this.request('ContentChannelItemAssociations')
+      .filter(`ContentChannelItemId eq ${id}`)
+      .cache({ ttl: 60 })
+      .get();
+
+    if (!associations || !associations.length) return this.request().empty();
+
+    return this.getFromIds(
+      associations.map(
+        ({ childContentChannelItemId }) => childContentChannelItemId
+      )
+    ).orderBy('Priority'); // Changed from Core, ordering by Priority instead of 'order'
+  };
+
   async getCoverImage(root) {
     const pickBestImage = (images) => {
       // TODO: there's probably a _much_ more explicit and better way to handle this


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Rather than using drag/drop ordering for their content in Willow, they have been using `priority` extensively to set order. By changing the sort order in two key methods, we can fix sorting for them. This is spefifically very helpful in Devos, where numbered devos where in the wrong order. 

### What design trade-offs/decisions were made?

n/a

### How do I test this PR?

1. Without downloading this PR, open up the API and run this query to see the invalid state
```
query col  {
  node(id:"ContentSeriesContentItem:7c24a0ba7984ef6a3af72ac09491ed83"){
    ... on ContentItem {
      title
      childContentItemsConnection {
        edges {
          node {
            id
            title
          }
        }
      }
    }
  }
}
```
2. Download this PR, and re-run the query and see the order corrected. 
3. Jump through the discover tab and make sure item ordering looks correct.

### What automated tests did you write?

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [x] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [x] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
