### PR TITLE
Fix future events now showing up on the calendar

### DIFF
--- a/packages/apollos-api/src/data/event/index.js
+++ b/packages/apollos-api/src/data/event/index.js
@@ -52,7 +52,6 @@ async function getMostRecentOccurenceForEvent(event) {
     .utcOffset(mostRecentOccurence);
 
   mostRecentOccurence = mostRecentOccurence.add(tzOffset, 'minutes').toDate();
-
   // Sometimes we have a "recurring rule"
   if (iCalEvent.rrule) {
     // Using the embeded RRule JS library, let's grab the next time this event occurs.
@@ -87,7 +86,11 @@ class dataSource extends Event.dataSource {
     const events = await this.findRecent()
       .andFilter(`CampusId eq ${campusId}`)
       .andFilter(
-        `(Schedule/EffectiveEndDate ge datetime'${new Date().toISOString()}' or Schedule/EffectiveEndDate eq null)`
+        `(Schedule/EffectiveEndDate ge datetime'${moment()
+          // we need to subtract a day. The EffectiveEndDate is often the morning of the current day.
+          // It's okay to get already occured events, because we filter them out later on.
+          .subtract(1, 'day')
+          .toISOString()}' or Schedule/EffectiveEndDate eq null)`
       )
       .get();
 


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

There's been a persistent but hard to track issue on Willow, where events that occur on the same day, occasionally don't show up on the day they occur. 

After a lot of tracking, I identified that some events have the `effectiveEndTime` listed as the morning of the day that the event occurs. This causes the event to be filtered out when fetching a list of events. This only happens for one-off events, which is why it doesn't always occur. 

We can fix it by fetching events that ended up to a day ago. This is safe, because we now filter out events before returning them to make sure we don't include events that have earlier than the current timestamp.

### What design trade-offs/decisions were made?

### How do I test this PR?

1. Open willow on master.
- You won't see a budgeting event as the first event on the South Barrington event list
2. Open willow on this PR
- You **will** see a budgeting event as the first event on the South Barrington event list. **(only true if testing before 7:00 EST on 02/10/20)**

### What automated tests did you write?

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, in storybook, and in-app
- [ ] Upload GIF(s) of iOS and Android
- [ ] Set a relevant reviewer

## REVIEW:

**Manual QA**

- [x] Manual QA on iOS and ensure it looks/behaves as expected
- [x] Manual QA on Android and ensure it looks/behaves as expected

**Code Review: Questions to consider**

- [x] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
